### PR TITLE
log_innodb_status is not safe

### DIFF
--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -2,16 +2,16 @@
 
 Gem::Specification.new do |s|
   s.name = %q{deadlock_retry}
-  s.version = "1.0.0"
+  s.version = "1.0.1.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Jamis Buck", "Mike Perham"]
+  s.authors = ["Jamis Buck", "Mike Perham", "Ben Osheroff", "Simon Wistow"]
   s.date = %q{2009-02-07}
   s.description = %q{Provides automatical deadlock retry and logging functionality for ActiveRecord and MySQL}
   s.email = %q{mperham@gmail.com}
   s.files = ["README", "Rakefile", "version.yml", "lib/deadlock_retry.rb", "test/deadlock_retry_test.rb", "CHANGELOG"]
   s.has_rdoc = true
-  s.homepage = %q{http://github.com/mperham/deadlock_retry}
+  s.homepage = %q{http://github.com/zendesk/deadlock_retry}
   s.rdoc_options = ["--inline-source", "--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.1}

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -1,10 +1,4 @@
 module DeadlockRetry
-
-  # Should we try to log innodb status -- if we don't have permission to,
-  # we actually break in-flight transactions, silently (!)
-  mattr_accessor :log_innodb_status
-  self.log_innodb_status = false
-
   def self.included(base)
     base.extend(ClassMethods)
     base.class_eval do
@@ -12,6 +6,16 @@ module DeadlockRetry
         alias_method_chain :transaction, :deadlock_handling
       end
     end
+  end
+
+  @@innodb_status_available = nil
+
+  def self.innodb_status_available?
+    @@innodb_status_available
+  end
+
+  def self.innodb_status_available=(bool)
+    @@innodb_status_available = bool
   end
 
   module ClassMethods
@@ -22,8 +26,11 @@ module DeadlockRetry
 
     MAXIMUM_RETRIES_ON_DEADLOCK = 3
 
+
     def transaction_with_deadlock_handling(*objects, &block)
       retry_count = 0
+
+      check_innodb_status_available
 
       begin
         transaction_without_deadlock_handling(*objects, &block)
@@ -33,7 +40,7 @@ module DeadlockRetry
           raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
           retry_count += 1
           logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
-          log_innodb_status if DeadlockRetry.log_innodb_status
+          log_innodb_status if DeadlockRetry.innodb_status_available?
           retry
         else
           raise
@@ -48,10 +55,27 @@ module DeadlockRetry
       connection.open_transactions != 0
     end
 
+    def show_innodb_status
+       self.connection.select_value("show innodb status")
+    end
+
+    # Should we try to log innodb status -- if we don't have permission to,
+    # we actually break in-flight transactions, silently (!)
+    def check_innodb_status_available
+      return unless DeadlockRetry.innodb_status_available?.nil?
+
+      begin
+        show_innodb_status
+        DeadlockRetry.innodb_status_available = true
+      rescue
+        DeadlockRetry.innodb_status_available = false
+      end
+    end
+
     def log_innodb_status
       # show innodb status is the only way to get visiblity into why
       # the transaction deadlocked.  log it.
-      lines = connection.select_value("show innodb status")
+      lines = show_innodb_status
       logger.warn "INNODB Status follows:"
       lines.each_line do |line|
         logger.warn line

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -20,6 +20,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 module DeadlockRetry
 
+  # Should we try to log innodb status -- if we don't have permission to,
+  # we actually break in-flight transactions, silently (!)
+  mattr_accessor :log_innodb_status
+  self.log_innodb_status = false
+
   def self.included(base)
     base.extend(ClassMethods)
     base.class_eval do
@@ -48,7 +53,7 @@ module DeadlockRetry
           raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
           retry_count += 1
           logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
-          log_innodb_status
+          log_innodb_status if DeadlockRetry.log_innodb_status
           retry
         else
           raise


### PR DESCRIPTION
Hi, 
(btw, this is the issue Simon Winstow was talking about)
I don't know if you'd want to use this code or work out another fix, but deadlock_retry can actually quite dangerous in a limited set of circumstances, due to the attempt to execute "SHOW INNODB STATUS". Here's what happens:
- transaction deadlocks
- call to log_innodb_status is made
- SHOW INNODB STATUS command fails, for a variety of reasons -- including that the user doesn't have permission to execute this command.
- the "rescue Exception" block kicks in, but mysql has already silently rolled-back our transaction because of the error in SHOW INNODB STATUS.
- the transaction continues, but is fundamentally broken and we've silently lost data. 
