### PR TITLE
move version out of deadlock_retry (was getting double require warnings)

### DIFF
--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8 -*-
 
-require './lib/deadlock_retry'
+$:.push File.expand_path("../lib", __FILE__)
+
+require "deadlock_retry/version"
 
 Gem::Specification.new do |s|
   s.name = %q{deadlock_retry}

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -1,9 +1,6 @@
 require 'active_support/core_ext/module/attribute_accessors'
 
 module DeadlockRetry
-
-  VERSION = '1.1.2'
-
   def self.included(base)
     base.extend(ClassMethods)
     base.class_eval do

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,0 +1,3 @@
+module DeadlockRetry
+  VERSION = '1.1.2'
+end


### PR DESCRIPTION
the gemfile has:
require "lib/deadlock_retry"

bundler essentially has:
require "deadlock_retry"

So the file was being included twice for me and causing warnings:

.bundle/ruby/1.8/bundler/gems/deadlock_retry-d09e498d44d5/lib/deadlock_retry.rb:5: warning: already initialized constant VERSION
.bundle/ruby/1.8/bundler/gems/deadlock_retry-d09e498d44d5/lib/deadlock_retry.rb:22: warning: already initialized constant DEADLOCK_ERROR_MESSAGES
.bundle/ruby/1.8/bundler/gems/deadlock_retry-d09e498d44d5/lib/deadlock_retry.rb:25: warning: already initialized constant MAXIMUM_RETRIES_ON_DEADLOCK
.bundle/ruby/1.8/bundler/gems/deadlock_retry-d09e498d44d5/lib/deadlock_retry.rb:52: warning: already initialized constant WAIT_TIMES

I did 2 things to correct:
1. I moved the version into it's own file (which is typical of the gems created via bundler)
2. I added the lib directory to the path in the gemfile, so the require was typical.

Either of these would have probably fixed the warnings.
But I followed bundler's new gem default format as a template.

If you have another path you would like me to take, please let me know and I'll resubmit.

Thanks for the plugin,
Keenan
