### PR TITLE
Environment variable for active record version, and Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -9,7 +9,9 @@ Gem::Specification.new do |s|
   s.description = s.summary = %q{Provides automatic deadlock retry and logging functionality for ActiveRecord and MySQL}
   s.email = %q{mperham@gmail.com}
   s.files = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
   s.add_development_dependency 'mocha'
+  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>3.0'
 end

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 
 # Change the version if you want to test a different version of ActiveRecord
-gem 'activerecord', ' ~>3.0'
+gem 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>3.0'
 require 'active_record'
 require 'active_record/version'
 puts "Testing ActiveRecord #{ActiveRecord::VERSION::STRING}"


### PR DESCRIPTION
I want to easily test this gem with a different version of active record

this patch will allow you to do the following to test:

export ACTIVERECORD_VERSION=2.3.11
bundle install
rake
