### PR TITLE
Update deadlock retry so it also retries duplicates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+PATH
+  remote: .
+  specs:
+    deadlock_retry (1.2.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (3.2.21)
+      activesupport (= 3.2.21)
+      builder (~> 3.0.0)
+    activerecord (3.2.21)
+      activemodel (= 3.2.21)
+      activesupport (= 3.2.21)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activesupport (3.2.21)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
+    arel (3.0.3)
+    builder (3.0.4)
+    i18n (0.7.0)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.11.0)
+    tzinfo (0.3.44)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 3.0)
+  deadlock_retry!
+  mocha
+
+BUNDLED WITH
+   1.10.3

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -18,7 +18,7 @@ module DeadlockRetry
       "Duplicate entry"
     ]
 
-    MAX_RETRIES_ON_STATEMENT_INVALID = 3
+    MAX_RETRIES_ON_STATEMENT_INVALID = 5
 
 
     def transaction_with_deadlock_handling(*objects, &block)
@@ -33,8 +33,7 @@ module DeadlockRetry
         if STATEMENT_INVALID_ERROR_MESSAGES.any? { |msg| error.message =~ /#{Regexp.escape(msg)}/i }
           raise if retry_count >= MAX_RETRIES_ON_STATEMENT_INVALID
           retry_count += 1
-          logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
-          log_innodb_status if DeadlockRetry.innodb_status_cmd
+          log(retry_count)
           exponential_pause(retry_count)
           retry
         else
@@ -56,7 +55,11 @@ module DeadlockRetry
 
     def in_nested_transaction?
       # open_transactions was added in 2.2's connection pooling changes.
-      connection.open_transactions != 0
+      open_transactions != 0
+    end
+
+    def open_transactions
+      connection.open_transactions
     end
 
     def show_innodb_status
@@ -79,7 +82,6 @@ module DeadlockRetry
           self.connection.select_value(cmd)
           DeadlockRetry.innodb_status_cmd = cmd
         rescue
-          logger.info "Cannot log innodb status: #{$!.message}"
           DeadlockRetry.innodb_status_cmd = false
         end
       else
@@ -87,16 +89,15 @@ module DeadlockRetry
       end
     end
 
-    def log_innodb_status
+    def log(retry_count)
+      logger.warn "retry_tx.attempt=#{retry_count} retry_tx.max_attempts=#{MAX_RETRIES_ON_STATEMENT_INVALID} retry_tx.opentransactions=#{open_transactions} retry_tx.innodbstatus=#{innodb_status}"
+    end
+
+    def innodb_status
       # show innodb status is the only way to get visiblity into why
       # the transaction deadlocked.  log it.
-      lines = show_innodb_status
-      logger.warn "INNODB Status follows:"
-      lines.each_line do |line|
-        logger.warn line
-      end
+      show_innodb_status
     rescue => e
-      # Access denied, ignore
       logger.info "Cannot log innodb status: #{e.message}"
     end
 

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -6,10 +6,11 @@ require 'active_record'
 require 'active_record/version'
 puts "Testing ActiveRecord #{ActiveRecord::VERSION::STRING}"
 
-require 'test/unit'
-require 'mocha'
+require 'minitest'
+require 'minitest/autorun'
+require 'mocha/mini_test'
 require 'logger'
-require "deadlock_retry"
+require_relative  "../lib/deadlock_retry"
 
 class MockModel
   @@open_transactions = 0
@@ -52,7 +53,8 @@ class MockModel
   include DeadlockRetry
 end
 
-class DeadlockRetryTest < Test::Unit::TestCase
+class DeadlockRetryTest < MiniTest::Test
+
   DEADLOCK_ERROR = "MySQL::Error: Deadlock found when trying to get lock"
   TIMEOUT_ERROR = "MySQL::Error: Lock wait timeout exceeded"
 
@@ -77,13 +79,13 @@ class DeadlockRetryTest < Test::Unit::TestCase
   end
 
   def test_error_if_limit_exceeded
-    assert_raise(ActiveRecord::StatementInvalid) do
+    assert_raises(ActiveRecord::StatementInvalid) do
       MockModel.transaction { raise ActiveRecord::StatementInvalid, DEADLOCK_ERROR }
     end
   end
 
   def test_error_if_unrecognized_error
-    assert_raise(ActiveRecord::StatementInvalid) do
+    assert_raises(ActiveRecord::StatementInvalid) do
       MockModel.transaction { raise ActiveRecord::StatementInvalid, "Something else" }
     end
   end

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -68,19 +68,19 @@ class DeadlockRetryTest < MiniTest::Test
   end
 
   def test_no_errors_with_deadlock
-    errors = [ DEADLOCK_ERROR ] * 3
+    errors = [ DEADLOCK_ERROR ] * DeadlockRetry::ClassMethods::MAX_RETRIES_ON_STATEMENT_INVALID
     assert_equal :success, MockModel.transaction { raise ActiveRecord::StatementInvalid, errors.shift unless errors.empty?; :success }
     assert errors.empty?
   end
 
   def test_no_errors_with_lock_timeout
-    errors = [ TIMEOUT_ERROR ] * 3
+    errors = [ TIMEOUT_ERROR ] * DeadlockRetry::ClassMethods::MAX_RETRIES_ON_STATEMENT_INVALID
     assert_equal :success, MockModel.transaction { raise ActiveRecord::StatementInvalid, errors.shift unless errors.empty?; :success }
     assert errors.empty?
   end
 
   def test_no_errors_with_duplicate
-    errors = [ DUPLICATE_ERROR ] * 3
+    errors = [ DUPLICATE_ERROR ] * DeadlockRetry::ClassMethods::MAX_RETRIES_ON_STATEMENT_INVALID
     assert_equal :success, MockModel.transaction { raise ActiveRecord::StatementInvalid, errors.shift unless errors.empty?; :success }
     assert errors.empty?
   end
@@ -117,11 +117,11 @@ class DeadlockRetryTest < MiniTest::Test
       MockModel.transaction do
         MockModel.transaction do
           errors += 1
-          raise ActiveRecord::StatementInvalid, TIMEOUT_ERROR unless errors > 3
+          raise ActiveRecord::StatementInvalid, TIMEOUT_ERROR unless errors > DeadlockRetry::ClassMethods::MAX_RETRIES_ON_STATEMENT_INVALID
         end
       end
     end
 
-    assert_equal 4, tries
+    assert_equal DeadlockRetry::ClassMethods::MAX_RETRIES_ON_STATEMENT_INVALID + 1, tries
   end
 end


### PR DESCRIPTION
This PR updates deadlock-retry so it also:
- retries duplicates
- appends information to the log using a custom format useful to be parsed with logstash
