### PR TITLE
Include adapters such as mysql2 and jdbc-mysql

### DIFF
--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -69,7 +69,7 @@ module DeadlockRetry
     def check_innodb_status_available
       return unless DeadlockRetry.innodb_status_cmd == nil
 
-      if self.connection.adapter_name == "MySQL"
+      if self.connection.adapter_name.downcase.include? "mysql"
         begin
           mysql_version = self.connection.select_rows('show variables like \'version\'')[0][1]
           cmd = if mysql_version < '5.5'

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Looking at the code, it doesn't seem like anything would not be compatible with any adapter that uses mysql, so making the check a little more flexible to make sure that whatever the adapter may be, it's connecting to a mysql database.
