### PR TITLE
GH actions fix set env deprecation

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,33 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      with:
+        ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,10 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Install dependencies

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
-  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'mocha', '~>1.0'
   s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>3.0'
 end

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
   s.add_development_dependency 'mocha', '~>1.0'
-  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>3.0'
+  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>4.0'
 end

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -5,7 +5,8 @@ module DeadlockRetry
     base.extend(ClassMethods)
     base.class_eval do
       class << self
-        alias_method_chain :transaction, :deadlock_handling
+        alias_method :transaction_without_deadlock_handling, :transaction
+        alias_method :transaction, :transaction_with_deadlock_handling
       end
     end
   end

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -46,12 +46,13 @@ module DeadlockRetry
 
     private
 
-    WAIT_TIMES = [0, 1, 2, 4, 8, 16, 32]
+    WAIT_TIMES = [0, 0.1, 0.2, 0.4, 0.8, 1.6, 3.2]
+    MAX_WAIT_TIME = 5
 
     def exponential_pause(count)
-      sec = WAIT_TIMES[count-1] || 32
-      # sleep 0, 1, 2, 4, ... seconds up to the MAXIMUM_RETRIES.
-      # Cap the pause time at 32 seconds.
+      sec = WAIT_TIMES[count - 1] || MAX_WAIT_TIME
+      # Sleep for a longer time each attempt.
+      # Cap the pause time at MAX_WAIT_TIME seconds.
       sleep(sec) if sec != 0
     end
 

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -91,12 +91,14 @@ module DeadlockRetry
     end
 
     def log_innodb_status
-      # show innodb status is the only way to get visiblity into why
-      # the transaction deadlocked.  log it.
+      # Showing the innodb status is the only way to get visiblity into why the
+      # transaction deadlocked.  Log it, along with a prefix including an id to
+      # enable easy extraction of the resulting status dump from the log.
       lines = show_innodb_status
-      logger.warn "INNODB Status follows:"
+      deadlock_id = SecureRandom.hex(4)
+      logger.info "(INNODB #{deadlock_id}) Status follows:"
       lines.each_line do |line|
-        logger.warn line
+        logger.info "(INNODB #{deadlock_id}) " + line
       end
     rescue => e
       # Access denied, ignore

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -61,7 +61,7 @@ module DeadlockRetry
     end
 
     def show_innodb_status
-       self.connection.select_value(DeadlockRetry.innodb_status_cmd)
+      self.connection.select_one(DeadlockRetry.innodb_status_cmd)['Status']
     end
 
     # Should we try to log innodb status -- if we don't have permission to,

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -32,7 +32,7 @@ module DeadlockRetry
       rescue ActiveRecord::StatementInvalid => error
         raise if in_nested_transaction?
         if DEADLOCK_ERROR_MESSAGES.any? { |msg| error.message =~ /#{Regexp.escape(msg)}/ }
-          raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
+          raise if retry_count > MAXIMUM_RETRIES_ON_DEADLOCK
           retry_count += 1
           logger.info "Deadlock detected on attempt #{retry_count}, restarting transaction. Exception: #{error.to_s}"
           log_innodb_status if DeadlockRetry.innodb_status_cmd

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -69,7 +69,7 @@ module DeadlockRetry
     def check_innodb_status_available
       return unless DeadlockRetry.innodb_status_cmd == nil
 
-      if self.connection.adapter_name == "MySQL"
+      if self.connection.adapter_name.downcase.include?('mysql')
         begin
           mysql_version = self.connection.select_rows('show variables like \'version\'')[0][1]
           cmd = if mysql_version < '5.5'

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -34,7 +34,7 @@ module DeadlockRetry
         if DEADLOCK_ERROR_MESSAGES.any? { |msg| error.message =~ /#{Regexp.escape(msg)}/ }
           raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
           retry_count += 1
-          logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
+          logger.info "Deadlock detected on attempt #{retry_count}, restarting transaction. Exception: #{error.to_s}"
           log_innodb_status if DeadlockRetry.innodb_status_cmd
           exponential_pause(retry_count)
           retry

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -7,7 +7,7 @@ require 'active_record/version'
 puts "Testing ActiveRecord #{ActiveRecord::VERSION::STRING}"
 
 require 'test/unit'
-require 'mocha'
+require 'mocha/test_unit'
 require 'logger'
 require "deadlock_retry"
 

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 
 # Change the version if you want to test a different version of ActiveRecord
-gem 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>3.0'
+gem 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>4.0'
 require 'active_record'
 require 'active_record/version'
 puts "Testing ActiveRecord #{ActiveRecord::VERSION::STRING}"

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -34,7 +34,7 @@ class MockModel
   end
 
   def self.select_one(sql)
-  {'Type' => '', 'Name' => '', 'Status' => 'INNODB STATUS INFO'}
+    {'Type' => '', 'Name' => '', 'Status' => 'INNODB STATUS INFO'}
   end
 
   def self.select_rows(sql)
@@ -54,7 +54,7 @@ end
 
 class MockModelOldMySQL < MockModel
   def self.select_one(sql)
-  {'Status' => 'OLD INNODB STATUS INFO'}
+    {'Status' => 'OLD INNODB STATUS INFO'}
   end
 
   def self.select_rows(sql)

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -38,7 +38,7 @@ class MockModel
   end
 
   def self.select_rows(sql)
-    [['version', '5.1.45']]
+    [['version', '5.5']]
   end
 
   def self.select_value(sql)
@@ -46,10 +46,20 @@ class MockModel
   end
 
   def self.adapter_name
-    "MySQL"
+    "Mysql2"
   end
 
   include DeadlockRetry
+end
+
+class MockModelOldMySQL < MockModel
+  def self.select_rows(sql)
+    [['version', '5.1.45']]
+  end
+
+  def self.adapter_name
+    "MySQL"
+  end
 end
 
 class DeadlockRetryTest < Test::Unit::TestCase
@@ -95,6 +105,12 @@ class DeadlockRetryTest < Test::Unit::TestCase
   def test_innodb_status_availability
     DeadlockRetry.innodb_status_cmd = nil
     MockModel.transaction {}
+    assert_equal "show engine innodb status", DeadlockRetry.innodb_status_cmd
+  end
+
+  def test_innodb_status_availability_for_old_mysql
+    DeadlockRetry.innodb_status_cmd = nil
+    MockModelOldMySQL.transaction {}
     assert_equal "show innodb status", DeadlockRetry.innodb_status_cmd
   end
 


### PR DESCRIPTION
Switched to setup-ruby@v1 action as recommended instead of the specification using a commit hash which was what it had defaulted to on creating the workflow file (and which was broken due to set-env deprecation).